### PR TITLE
Introduce attempt_number to RequestMetadata

### DIFF
--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -2119,7 +2119,7 @@ message RequestMetadata {
   // or equality across invocations, though some client tools may offer these guarantees.
   string configuration_id = 7;
 
-  // If Bazel automatically retries an invocation, this value is set to the
+  // If the client automatically retries an invocation, this value is set to the
   // number of invocation attempts that have been started so far. For example, a
   // value of 2 would indicate that it is the second attempt.
   int32 attempt_number = 8;

--- a/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/build/bazel/remote/execution/v2/remote_execution.proto
@@ -2118,4 +2118,9 @@ message RequestMetadata {
   // There is no expectation that this value will have any particular structure,
   // or equality across invocations, though some client tools may offer these guarantees.
   string configuration_id = 7;
+
+  // If Bazel automatically retries an invocation, this value is set to the
+  // number of invocation attempts that have been started so far. For example, a
+  // value of 2 would indicate that it is the second attempt.
+  int32 attempt_number = 8;
 }


### PR DESCRIPTION
I'd like to propose adding a field to RequestMetadata that indicates if this request was a retry from the client. This allows the remote server to choose their behavior differently when this invocation had to be retried due to different reasons, and track the stats with retried invocations. 